### PR TITLE
Drop mention of ontologies

### DIFF
--- a/cfp.md
+++ b/cfp.md
@@ -114,4 +114,4 @@ Venue details
 
 ## What is W3C?
 
-The [World Wide Web Consortium (W3C)](https://www.w3.org) is a voluntary standards consortium that convenes companies and communities to help structure productive discussions around existing and emerging technologies, and offers a Royalty-Free patent framework for Web Recommendations. We focus primarily on client-side (browser) technologies, and also have a mature history of vocabulary (or “ontology”) development. W3C develops work based on the priorities of our members and our community.
+The [World Wide Web Consortium (W3C)](https://www.w3.org) is a voluntary standards consortium that convenes companies and communities to help structure productive discussions around existing and emerging technologies, and offers a Royalty-Free patent framework for Web Recommendations. We focus primarily on client-side (browser) technologies. W3C develops work based on the priorities of our members and our community.


### PR DESCRIPTION
That's not wrong, but it is not terribly relevant, and overstates the importance of that activity compared to the rest of what W3C does.